### PR TITLE
Adding option to force pull even when the image already exists.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.zenvia.komposer'
-version '1.2.1'
+version '1.2.2'
 
 apply plugin: 'groovy'
 apply plugin: 'jacoco'
@@ -36,7 +36,7 @@ dependencies {
     compile group: 'junit', name: 'junit', version: '4.11'
 
     testCompile "org.spockframework:spock-core:1.0-groovy-2.4"
-    testCompile 'com.athaydes:spock-reports:1.2.5'
+    testCompile 'com.athaydes:spock-reports:1.2.7'
 
     testRuntime 'cglib:cglib-nodep:3.1'
     testRuntime group: 'ch.qos.logback', name:'logback-classic', version: '1.0.0'

--- a/src/main/groovy/com/zenvia/komposer/junit/KomposerRule.groovy
+++ b/src/main/groovy/com/zenvia/komposer/junit/KomposerRule.groovy
@@ -12,9 +12,12 @@ class KomposerRule extends ExternalResource {
     private final KomposerRunner runner
     private final String composeFile
     private Map<String, Komposition> runningServices
+    private final dockerCfg = null
     private final pull = true
     private final privateNetwork = false
+    private final forcePull = false
 
+    @Deprecated
     def KomposerRule(String compose, String dockerCfg, Boolean pull = true, Boolean privateNetwork = false) {
         this.runner = new KomposerRunner(dockerCfg, privateNetwork)
         this.composeFile = compose
@@ -33,9 +36,30 @@ class KomposerRule extends ExternalResource {
         this.composeFile = composeFile
     }
 
+    def KomposerRule(options = []) {
+
+        def defaultOptions = [
+            compose:        null,
+            dockerCfg:      null,
+            pull:           true,
+            privateNetwork: false,
+            forcePull:      false
+        ]
+
+        options = defaultOptions << options;
+
+        this.composeFile = options.compose;
+        this.dockerCfg = options.dockerCfg;
+        this.pull = options.pull;
+        this.privateNetwork = options.privateNetwork;
+        this.forcePull = options.forcePull;
+
+        this.runner = new KomposerRunner(this.dockerCfg, this.privateNetwork)
+    }
+
     @Override
     void before() throws Throwable {
-        this.runningServices = this.runner.up(this.composeFile, pull)
+        this.runningServices = this.runner.up(this.composeFile, this.pull, this.forcePull)
     }
 
     @Override

--- a/src/main/groovy/com/zenvia/komposer/runner/KomposerRunner.groovy
+++ b/src/main/groovy/com/zenvia/komposer/runner/KomposerRunner.groovy
@@ -24,7 +24,7 @@ class KomposerRunner {
     private DefaultDockerClient dockerClient
     private DefaultDockerClient originalDockerClient
     private final KomposerBuilder komposerBuilder
-    private static final SECONDDS_TO_KILL = 10
+    private static final SECONDS_TO_KILL = 10
     private host
     private final privateNetwork
     private networkSetup
@@ -90,7 +90,7 @@ class KomposerRunner {
         return this.dockerClient.listContainers(DockerClient.ListContainersParam.allContainers())
     }
 
-    def up(String composeFile, Boolean pull = true) {
+    def up(String composeFile, Boolean pull = true, Boolean forcePull = false) {
         composeFile ?: 'docker-compose.yml'
 
         def file = new File(composeFile)
@@ -98,7 +98,7 @@ class KomposerRunner {
 
             log.info("Starting services on ${composeFile}")
 
-            def configs = this.komposerBuilder.build(file, pull)
+            def configs = this.komposerBuilder.build(file, pull, forcePull)
 
             def result = [:]
             configs.each { config ->
@@ -114,7 +114,7 @@ class KomposerRunner {
                 def creation = this.dockerClient.createContainer(containerConfig, containerName)
 
                 log.info("[$containerName] Starting container...")
-                dockerClient.startContainer(creation.id)
+                this.dockerClient.startContainer(creation.id)
 
                 log.info("[$containerName] Gathering container info...")
                 def info = this.dockerClient.inspectContainer(creation.id)
@@ -182,14 +182,14 @@ class KomposerRunner {
     }
 
     def stop(containerID) {
-        this.dockerClient.stopContainer(containerID, SECONDDS_TO_KILL)
-        Thread.sleep(SECONDDS_TO_KILL * 1000 + 2000)
+        this.dockerClient.stopContainer(containerID, SECONDS_TO_KILL)
+        Thread.sleep(SECONDS_TO_KILL * 1000 + 2000)
         return this.dockerClient.inspectContainer(containerID)
     }
 
     def start(containerID) {
         this.dockerClient.startContainer(containerID)
-        Thread.sleep(SECONDDS_TO_KILL * 1000)
+        Thread.sleep(SECONDS_TO_KILL * 1000)
         return this.dockerClient.inspectContainer(containerID)
     }
 

--- a/src/test/groovy/com/zenvia/komposer/junit/KomposerRuleSpec.groovy
+++ b/src/test/groovy/com/zenvia/komposer/junit/KomposerRuleSpec.groovy
@@ -15,9 +15,12 @@ class KomposerRuleSpec extends Specification {
     static KomposerRule rule
 
     def setupSpec() {
-        def composeFile = 'src/test/resources/docker-compose-test.yml'
-        def cfgFile = 'src/test/resources/docker.properties'
-        rule = new KomposerRule(composeFile, cfgFile, false)
+        def options = [
+                compose: 'src/test/resources/docker-compose-test.yml',
+                dockerCfg: 'src/test/resources/docker.properties'
+        ]
+
+        rule = new KomposerRule(options)
     }
 
     def "getContainers"() {

--- a/src/test/groovy/com/zenvia/komposer/runner/KomposerRunnerSpec.groovy
+++ b/src/test/groovy/com/zenvia/komposer/runner/KomposerRunnerSpec.groovy
@@ -38,6 +38,25 @@ class KomposerRunnerSpec extends Specification {
             result.sender.containerInfo == info
     }
 
+    def "up with force pull"() {
+        given:
+            def file = 'src/test/resources/docker-compose.yml'
+            def creation = new ContainerCreation()
+            creation.id = '9998877'
+            def info = new ContainerInfo()
+            def stream = Mock(LogStream)
+        when:
+            dockerClient.createContainer(_, _) >> creation
+            dockerClient.inspectContainer(creation.id) >> info
+            dockerClient.logs(_, _) >> stream
+            def result = runner.up(file, true, true)
+        then:
+            result
+            result.sender.containerId == services.sender.containerId
+            result.sender.containerName.contains(services.sender.containerName)
+            result.sender.containerInfo == info
+    }
+
     def "down"() {
         when:
             runner.down(services)


### PR DESCRIPTION
This PR contains the inclusion of the "force pull" option for overriding of current image on the docker host.

Before: docker-komposer only pull docker image if image is not found
After: docker-komposer can pull docker image even if the image already exists on local
