### PR TITLE
refs #22 - Weave is not being closed properly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.zenvia.komposer'
-version '1.2.2'
+version '1.2.3'
 
 apply plugin: 'groovy'
 apply plugin: 'jacoco'

--- a/src/main/groovy/com/zenvia/komposer/runner/KomposerRunner.groovy
+++ b/src/main/groovy/com/zenvia/komposer/runner/KomposerRunner.groovy
@@ -158,7 +158,6 @@ class KomposerRunner {
         }
 
         if (this.privateNetwork) {
-            this.dockerClient.close()
             this.dockerClient = this.originalDockerClient
             this.networkSetup.stop(this.dockerClient)
         }


### PR DESCRIPTION
The solution found is to ignore the closing of docker client because it apparently affects other docker clients. 
With this change all the containers are closed as expected.
