### PR TITLE
#21 - Create retry policy to docker hub interaction

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.zenvia.komposer'
-version '1.2.3'
+version '1.2.4'
 
 apply plugin: 'groovy'
 apply plugin: 'jacoco'

--- a/src/main/groovy/com/zenvia/komposer/junit/KomposerRule.groovy
+++ b/src/main/groovy/com/zenvia/komposer/junit/KomposerRule.groovy
@@ -16,14 +16,7 @@ class KomposerRule extends ExternalResource {
     private final pull = true
     private final privateNetwork = false
     private final forcePull = false
-
-    @Deprecated
-    def KomposerRule(String compose, String dockerCfg, Boolean pull = true, Boolean privateNetwork = false) {
-        this.runner = new KomposerRunner(dockerCfg, privateNetwork)
-        this.composeFile = compose
-        this.pull = pull
-        this.privateNetwork = privateNetwork
-    }
+    private final maxAttempts = 5
 
     def KomposerRule(String compose, Boolean pull = true) {
         this.runner = new KomposerRunner()
@@ -43,7 +36,8 @@ class KomposerRule extends ExternalResource {
             dockerCfg:      null,
             pull:           true,
             privateNetwork: false,
-            forcePull:      false
+            forcePull:      false,
+            maxAttempts:    5
         ]
 
         options = defaultOptions << options;
@@ -53,13 +47,14 @@ class KomposerRule extends ExternalResource {
         this.pull = options.pull;
         this.privateNetwork = options.privateNetwork;
         this.forcePull = options.forcePull;
+        this.maxAttempts = options.maxAttempts;
 
         this.runner = new KomposerRunner(this.dockerCfg, this.privateNetwork)
     }
 
     @Override
     void before() throws Throwable {
-        this.runningServices = this.runner.up(this.composeFile, this.pull, this.forcePull)
+        this.runningServices = this.runner.up(this.composeFile, this.maxAttempts, this.pull, this.forcePull)
     }
 
     @Override

--- a/src/main/groovy/com/zenvia/komposer/runner/KomposerRunner.groovy
+++ b/src/main/groovy/com/zenvia/komposer/runner/KomposerRunner.groovy
@@ -90,7 +90,7 @@ class KomposerRunner {
         return this.dockerClient.listContainers(DockerClient.ListContainersParam.allContainers())
     }
 
-    def up(String composeFile, Boolean pull = true, Boolean forcePull = false) {
+    def up(String composeFile, Integer maxAttempts, Boolean pull = true, Boolean forcePull = false) {
         composeFile ?: 'docker-compose.yml'
 
         def file = new File(composeFile)
@@ -98,7 +98,7 @@ class KomposerRunner {
 
             log.info("Starting services on ${composeFile}")
 
-            def configs = this.komposerBuilder.build(file, pull, forcePull)
+            def configs = this.komposerBuilder.build(file, maxAttempts, pull, forcePull)
 
             def result = [:]
             configs.each { config ->

--- a/src/test/groovy/com/zenvia/komposer/integration/KomposerRunnerIntegrationSpec.groovy
+++ b/src/test/groovy/com/zenvia/komposer/integration/KomposerRunnerIntegrationSpec.groovy
@@ -8,12 +8,12 @@ import spock.lang.Specification
 /**
  * @author Tiago de Oliveira
  * */
+@Ignore
 @Slf4j
 class KomposerRunnerIntegrationSpec extends Specification {
 
     def runner, containers
 
-    @Ignore
     def "start a container with a private network and leave the room clean when getting out"() {
         given: 'a compose file with two containers without any link between'
             def privateNetwork = true

--- a/src/test/groovy/com/zenvia/komposer/runner/KomposerRunnerSpec.groovy
+++ b/src/test/groovy/com/zenvia/komposer/runner/KomposerRunnerSpec.groovy
@@ -14,6 +14,7 @@ class KomposerRunnerSpec extends Specification {
     DefaultDockerClient dockerClient = Mock(constructorArgs: [DefaultDockerClient.fromEnv()])
     def runner = new KomposerRunner(dockerClient)
     def services = ['sender': [containerId: '9998877', containerName: 'komposer_resources_sender_']]
+    def maxAttempts = 5
 
     def setup() {
         runner.host = 'http://teste:5656'
@@ -30,7 +31,7 @@ class KomposerRunnerSpec extends Specification {
             dockerClient.createContainer(_, _) >> creation
             dockerClient.inspectContainer(creation.id) >> info
             dockerClient.logs(_, _) >> stream
-            def result = runner.up(file)
+            def result = runner.up(file, maxAttempts)
         then:
             result
             result.sender.containerId == services.sender.containerId
@@ -49,7 +50,7 @@ class KomposerRunnerSpec extends Specification {
             dockerClient.createContainer(_, _) >> creation
             dockerClient.inspectContainer(creation.id) >> info
             dockerClient.logs(_, _) >> stream
-            def result = runner.up(file, true, true)
+            def result = runner.up(file, maxAttempts, true, true)
         then:
             result
             result.sender.containerId == services.sender.containerId


### PR DESCRIPTION
Target version: 1.2.4

Changes:
- Implemented retry policy on pull operation (default is 5 attempts, but it is configurable by field maxAttempts on options)
- Removed @Deprecated constructor
- Moving @Ignore annotation to the top of class to remove warning when run unit tests
