### PR TITLE
refs #27 - "localhost" is not accepted as host on getHost() method

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.zenvia.komposer'
-version '1.2.4'
+version '1.2.5'
 
 apply plugin: 'groovy'
 apply plugin: 'jacoco'

--- a/src/main/groovy/com/zenvia/komposer/runner/KomposerNetworkSetup.groovy
+++ b/src/main/groovy/com/zenvia/komposer/runner/KomposerNetworkSetup.groovy
@@ -57,7 +57,7 @@ class KomposerNetworkSetup {
     def getHost(dockerClient) {
         def container = createNetworkAdminContainer('proxy-env', extractHost(dockerClient))
         def logs = startAdminContainer(container, dockerClient)
-        def hostMatcher = (logs.split('\n').last() =~ /(?:[0-9]{1,3}\.){3}[0-9]{1,3}.*/)
+        def hostMatcher = (logs.split('\n').last() =~ /localhost:\d{1,5}|\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}:\d{1,5}/)
         def host
         if (hostMatcher.size() > 0) {
             host = hostMatcher[0]

--- a/src/test/groovy/com/zenvia/komposer/integration/KomposerRunnerIntegrationSpec.groovy
+++ b/src/test/groovy/com/zenvia/komposer/integration/KomposerRunnerIntegrationSpec.groovy
@@ -2,18 +2,18 @@ package com.zenvia.komposer.integration
 
 import com.zenvia.komposer.runner.KomposerRunner
 import groovy.util.logging.Slf4j
-import spock.lang.Ignore
 import spock.lang.Specification
 
 /**
  * @author Tiago de Oliveira
  * */
-@Ignore
 @Slf4j
 class KomposerRunnerIntegrationSpec extends Specification {
 
     def runner, containers
+    def maxAttempts = 5
 
+    // OBS: docker rm -vf $(docker ps -qa)
     def "start a container with a private network and leave the room clean when getting out"() {
         given: 'a compose file with two containers without any link between'
             def privateNetwork = true
@@ -22,7 +22,7 @@ class KomposerRunnerIntegrationSpec extends Specification {
         when: 'I create a komposerRunner with a private network'
             runner = new KomposerRunner(dockerConfigFile, privateNetwork)
         and: 'I start the runner'
-            containers = runner.up(dockerComposeFile, true)
+            containers = runner.up(dockerComposeFile, maxAttempts, true)
         then: 'I expect the containers to be created'
             containers
         and: 'the docker client to be running with the new proxy server'
@@ -56,5 +56,4 @@ class KomposerRunnerIntegrationSpec extends Specification {
             log.error("Error on clean up ", e)
         }
     }
-
 }


### PR DESCRIPTION
Changed IP format to a cleaner regex
Added "localhost" to regex
Fixing and enabling KomposerRunnerIntegrationSpec
