### PR TITLE
#29 - Add option to cleanup all containers before run tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group 'com.zenvia.komposer'
-version '1.2.5'
+version '1.2.6'
 
 apply plugin: 'groovy'
 apply plugin: 'jacoco'

--- a/src/main/groovy/com/zenvia/komposer/junit/KomposerRule.groovy
+++ b/src/main/groovy/com/zenvia/komposer/junit/KomposerRule.groovy
@@ -17,6 +17,7 @@ class KomposerRule extends ExternalResource {
     private final privateNetwork = false
     private final forcePull = false
     private final maxAttempts = 5
+    private final cleanup = true
 
     def KomposerRule(String compose, Boolean pull = true) {
         this.runner = new KomposerRunner()
@@ -37,7 +38,8 @@ class KomposerRule extends ExternalResource {
             pull:           true,
             privateNetwork: false,
             forcePull:      false,
-            maxAttempts:    5
+            maxAttempts:    5,
+            cleanup:        true
         ]
 
         options = defaultOptions << options;
@@ -48,8 +50,9 @@ class KomposerRule extends ExternalResource {
         this.privateNetwork = options.privateNetwork;
         this.forcePull = options.forcePull;
         this.maxAttempts = options.maxAttempts;
+        this.cleanup = options.cleanup;
 
-        this.runner = new KomposerRunner(this.dockerCfg, this.privateNetwork)
+        this.runner = new KomposerRunner(this.dockerCfg, this.privateNetwork, this.cleanup)
     }
 
     @Override


### PR DESCRIPTION
Now, by default, the plugin will clean up (kill and remove) all previous containers in order to garantee a clean environment to execute the test.

Version: 1.2.6
